### PR TITLE
Adding back ring.resp to service.clj

### DIFF
--- a/src/bpmock_facephi/service.clj
+++ b/src/bpmock_facephi/service.clj
@@ -3,6 +3,7 @@
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition :refer [defroutes]]
+            [ring.util.response :as ring-resp]
             [bpmock-facephi.response :as res]
             [cheshire.core :as json]))
 


### PR DESCRIPTION
Home and about pages are still using ring-resp directly
